### PR TITLE
Fix MSK broker endpoints

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -65,7 +65,7 @@ jobs:
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
           BUILD_ARGS: "--load"
-          VERSION: "0.27-sb1-6"
+          VERSION: "0.27-sb1-7"
           CHANNEL: "master"
           DOCKER_REGISTRY: ghcr.io/sparebank1utvikling
 
@@ -82,6 +82,6 @@ jobs:
       - name: Promote Artifacts
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/} PLATFORMS=linux_amd64
         env:
-          VERSION: "0.27-sb1-6"
+          VERSION: "0.27-sb1-7"
           CHANNEL: "master"
           DOCKER_REGISTRY: ghcr.io/sparebank1utvikling

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -94,7 +94,7 @@ func preObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.Describe
 // endpoints starts with b-. The ports can also be different.
 func zooKeeperToClusterEndpoint(connString string, srcPort, dstPort string) string {
 	re := regexp.MustCompile(fmt.Sprintf(`^z(\S+):%s`, srcPort))
-	parts := make([]string, 0, len(connString))
+	parts := make([]string, 0, 3)
 	for _, s := range strings.Split(connString, ",") {
 		parts = append(parts, re.ReplaceAllString(s, fmt.Sprintf("b$1:%s", dstPort)))
 	}

--- a/pkg/controller/kafka/cluster/setup_test.go
+++ b/pkg/controller/kafka/cluster/setup_test.go
@@ -1,0 +1,36 @@
+package cluster
+
+import (
+	"testing"
+)
+
+func Test_zooKeeperToClusterEndpoint(t *testing.T) {
+	type args struct {
+		connString string
+		srcPort    string
+		dstPort    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "OK",
+			args: args{
+				connString: "z-1.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9092,z-2.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9092,z-3.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9092",
+				srcPort:    "9092",
+				dstPort:    "9094",
+			},
+			want: "b-1.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9094,b-2.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9094,b-3.kafkacluster.xxxxxx.c4.kafka.eu-north-1.amazonaws.com:9094",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := zooKeeperToClusterEndpoint(tt.args.connString, tt.args.srcPort, tt.args.dstPort); got != tt.want {
+				t.Errorf("zooKeeperToClusterEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Nåværende versjon av provider returnerer zookeeper-addresse som clusterendporints. Dette skal fikse dette.